### PR TITLE
Add iohk-nix overlay to the shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,8 @@ let
   # If haskellNix is not found run:
   #   niv add input-output-hk/haskell.nix -n haskellNix
 
+  iohkNix = import sources.iohkNix {};
+
   # Import nixpkgs and pass the haskell.nix provided nixpkgsArgs
   pkgs = import
     # haskell.nix provides access to the nixpkgs pins which are used by our CI,
@@ -18,7 +20,10 @@ let
     haskellNix.sources.nixpkgs-unstable
     # These arguments passed to nixpkgs, include some patches and also
     # the haskell.nix functionality itself as an overlay.
-    haskellNix.nixpkgsArgs;
+    {
+      overlays = haskellNix.nixpkgsArgs.overlays ++ iohkNix.overlays.crypto;
+      config = haskellNix.nixpkgsArgs.config;
+    };
 in pkgs.haskell-nix.project {
   # 'cleanGit' cleans a source directory based on the files known by git
   src = pkgs.haskell-nix.haskellLib.cleanGit {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/5f244caea76105b63d826911b2a1563d33ff1cdc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "iohkNix": {
+        "branch": "release-21.05",
+        "description": "IOHK nix lib, packages and overlays",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "6a20fc25392d102170406a164e978ebaad3d20fc",
+        "sha256": "0i7j0vjcgplmzi4w45hp6crmcahf6b0pixx1r77sdppwlpsvijli",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/6a20fc25392d102170406a164e978ebaad3d20fc.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR attempts to fix the following error:
```
$ cabal repl contractmodel
In order, the following will be built (use -v for more details):
 - contractmodel-0.1.0.0 (lib) (ephemeral targets)
Preprocessing library for contractmodel-0.1.0.0..
GHCi, version 8.10.7: https://www.haskell.org/ghc/  :? for help
<command line>: /home/max/.cabal/store/ghc-8.10.7/cardano-crypto-praos-2.0.0-d7ccdd4669165cffc986be0278dcd7a39bf5c34b1
c2d5c6547b88e7f77c2d3fd/lib/libHScardano-crypto-praos-2.0.0-d7ccdd4669165cffc986be0278dcd7a39bf5c34b1c2d5c6547b88e7f77
c2d3fd-ghc8.10.7.so: undefined symbol: crypto_vrf_ietfdraft03_proof_to_hash
cabal: repl failed for contractmodel-0.1.0.0.
```